### PR TITLE
Add version in pyproject workaround setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist
 .DS_Store
 .mypy_cache
 skybell_test@testcom.pickle
+src/aioskybellgen.egg-info/dependency_links.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aioskybellgen"
-dynamic = ["version"]
+version = "0.1.5"
 dependencies = [
 	"aiofiles>=0.3.0",
 	"aiohttp>=3.6.1,<4.0",


### PR DESCRIPTION
Add version in pyproject workaround setuptools. Setuptools isn't honoring the tag on the release